### PR TITLE
Add compatibility with Raised mod

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -33,6 +33,7 @@ lithium_version_1_18 = mc1.18.2-0.7.9
 starlight_version_1_18 = 1.0.2+1.18.2
 smoothboot_version_1_18 = 3692365
 no_fade_version_1_18 = 3550935
+raised_version_1_18 = Fabric-1.18.2-1.1.1
 # 1.19
 lazydfu_version_1_19 = 0.1.2
 smoothboot_version_1_19 = 3692365

--- a/microdurability-1.18/build.gradle
+++ b/microdurability-1.18/build.gradle
@@ -52,6 +52,7 @@ dependencies {
         modRuntimeOnly "maven.modrinth:starlight:${project.starlight_version_1_18}"
         modRuntimeOnly "curse.maven:smooth-boot-415758:${project.smoothboot_version_1_18}"
         modRuntimeOnly "curse.maven:no-fade-452768:${project.no_fade_version_1_18}"
+        modRuntimeOnly "maven.modrinth:raised:${project.raised_version_1_18}"
 
         // PSA: Some older mods, compiled on Loom 0.2.1, might have outdated Maven POMs.
         // You may need to force-disable transitiveness on them.

--- a/microdurability-core/src/main/java/com/github/reviversmc/microdurability/RendererBase.java
+++ b/microdurability-core/src/main/java/com/github/reviversmc/microdurability/RendererBase.java
@@ -2,6 +2,7 @@ package com.github.reviversmc.microdurability;
 
 import com.mojang.blaze3d.systems.RenderSystem;
 import net.fabricmc.fabric.api.client.rendering.v1.HudRenderCallback;
+import net.fabricmc.loader.api.FabricLoader;
 import net.minecraft.client.MinecraftClient;
 import net.minecraft.client.gui.DrawableHelper;
 import net.minecraft.client.render.*;
@@ -42,6 +43,9 @@ public abstract class RendererBase extends DrawableHelper implements HudRenderCa
         int x = scaledWidth/2 - 7;
         int y = scaledHeight - 30;
         if (mc.player.experienceLevel > 0) y -= 6;
+        if (FabricLoader.getInstance().getObjectShare().get("raised:distance") instanceof Integer distance) {
+            y -= distance;
+        }
         boolean canRenderArmorBar = true;
 
         // Render armor low durability warning


### PR DESCRIPTION
I apologise in advance because I don't know what I'm doing, but it works. microDurability's armour bars are aligned correctly and move with the hotbar when using Raised's hotkeys.

Closes #11 

![Screenshot 1 - default Raised position](https://user-images.githubusercontent.com/23169302/171931007-fa7a943c-5c59-4b6b-a941-11811ee21a69.jpg)
![Screenshot 2 - way up](https://user-images.githubusercontent.com/23169302/171930831-a1002f9a-53e9-461a-b321-145d40b2b590.jpg)