### PR TITLE
Implement #5 + localization for config comments (now tooltips) and mod description in Mod Menu 

### DIFF
--- a/microdurability-core/src/main/java/com/github/reviversmc/microdurability/ModConfig.java
+++ b/microdurability-core/src/main/java/com/github/reviversmc/microdurability/ModConfig.java
@@ -15,6 +15,12 @@ public class ModConfig implements ConfigData {
     public static class ArmorBars {
         public boolean displayArmorBars = true;
         public boolean displayBarsForUndamagedArmor = true;
+
+        @ConfigEntry.Gui.Tooltip
+        public boolean useCustomColorInBarsForUndamagedArmor = true;
+
+        @ConfigEntry.ColorPicker(allowAlpha = true)
+        public int customColorInBarsForUndamagedArmor = 0xFFFFFFFF;
     }
 
 

--- a/microdurability-core/src/main/java/com/github/reviversmc/microdurability/ModConfig.java
+++ b/microdurability-core/src/main/java/com/github/reviversmc/microdurability/ModConfig.java
@@ -27,15 +27,15 @@ public class ModConfig implements ConfigData {
         public boolean displayWarningForArmor = true;
         public boolean onlyOnMendingItems = true;
 
-        @Comment("An item's durability has to be below both the minimum point value and the minimum percentage for the warning to show!")
+        @ConfigEntry.Gui.Tooltip
         @ConfigEntry.BoundedDiscrete(min = 1, max = 250)
         public int minDurabilityPointsBeforeWarning = 100;
 
-        @Comment("An item's durability has to be below both the minimum point value and the minimum percentage for the warning to show!")
+        @ConfigEntry.Gui.Tooltip
         @ConfigEntry.BoundedDiscrete(min = 1, max = 99)
         public int minDurabilityPercentageBeforeWarning = 10;
 
-        @Comment("Set to 0 to disable blinking")
+        @ConfigEntry.Gui.Tooltip
         @ConfigEntry.BoundedDiscrete(min = 0, max = 5)
         public float blinkTime = 1f;
     }

--- a/microdurability-core/src/main/java/com/github/reviversmc/microdurability/ModConfig.java
+++ b/microdurability-core/src/main/java/com/github/reviversmc/microdurability/ModConfig.java
@@ -16,6 +16,7 @@ public class ModConfig implements ConfigData {
         public boolean displayArmorBars = true;
         public boolean displayBarsForUndamagedArmor = true;
 
+        @Comment("If armor is undamaged, its bar will have custom color.")
         @ConfigEntry.Gui.Tooltip
         public boolean useCustomColorInBarsForUndamagedArmor = true;
 
@@ -33,14 +34,17 @@ public class ModConfig implements ConfigData {
         public boolean displayWarningForArmor = true;
         public boolean onlyOnMendingItems = true;
 
+        @Comment("An item's durability has to be below both the minimum point value and the minimum percentage for the warning to show!")
         @ConfigEntry.Gui.Tooltip
         @ConfigEntry.BoundedDiscrete(min = 1, max = 250)
         public int minDurabilityPointsBeforeWarning = 100;
 
+        @Comment("An item's durability has to be below both the minimum point value and the minimum percentage for the warning to show!")
         @ConfigEntry.Gui.Tooltip
         @ConfigEntry.BoundedDiscrete(min = 1, max = 99)
         public int minDurabilityPercentageBeforeWarning = 10;
 
+        @Comment("Set to 0 to disable blinking.")
         @ConfigEntry.Gui.Tooltip
         @ConfigEntry.BoundedDiscrete(min = 0, max = 5)
         public float blinkTime = 1f;

--- a/microdurability-core/src/main/java/com/github/reviversmc/microdurability/RendererBase.java
+++ b/microdurability-core/src/main/java/com/github/reviversmc/microdurability/RendererBase.java
@@ -92,7 +92,12 @@ public abstract class RendererBase extends DrawableHelper implements HudRenderCa
         int width = stack.getItemBarStep();
         int color = stack.getItemBarColor();
         this.renderGuiQuad(bufferBuilder, x, y, 13, 2, 0, 0, 0, 255);
-        this.renderGuiQuad(bufferBuilder, x, y, width, 1, color >> 16 & 255, color >> 8 & 255, color & 255, 255);
+        if (!stack.isDamaged() && MicroDurability.config.armorBars.useCustomColorInBarsForUndamagedArmor) {
+            int argb = MicroDurability.config.armorBars.customColorInBarsForUndamagedArmor;
+            this.renderGuiQuad(bufferBuilder, x, y, 13, 1, ((argb >> 16) & 0xFF) & 255, ((argb >> 8) & 0xFF) & 255, (argb & 0xFF) & 255, ((argb >> 24) & 0xFF) & 255);
+        } else {
+            this.renderGuiQuad(bufferBuilder, x, y, width, 1, color >> 16 & 255, color >> 8 & 255, color & 255, 255);
+        }
         RenderSystem.enableBlend();
         RenderSystem.enableTexture();
         RenderSystem.enableDepthTest();

--- a/microdurability-core/src/main/resources/assets/microdurability/lang/en_us.json
+++ b/microdurability-core/src/main/resources/assets/microdurability/lang/en_us.json
@@ -10,6 +10,12 @@
   "text.autoconfig.microdurability.option.lowDurabilityWarning.displayWarningForArmor": "Display warning for armor",
   "text.autoconfig.microdurability.option.lowDurabilityWarning.onlyOnMendingItems": "Display only on mending items",
   "text.autoconfig.microdurability.option.lowDurabilityWarning.minDurabilityPointsBeforeWarning": "Minimum durability points before showing the warning",
+  "text.autoconfig.microdurability.option.lowDurabilityWarning.minDurabilityPointsBeforeWarning.@Tooltip": "An item's durability has to be below both the minimum point value and the minimum percentage for the warning to show!",
   "text.autoconfig.microdurability.option.lowDurabilityWarning.minDurabilityPercentageBeforeWarning": "Minimum durability percentage before showing the warning",
-  "text.autoconfig.microdurability.option.lowDurabilityWarning.blinkTime": "Blink speed (in seconds)"
+  "text.autoconfig.microdurability.option.lowDurabilityWarning.minDurabilityPercentageBeforeWarning.@Tooltip": "An item's durability has to be below both the minimum point value and the minimum percentage for the warning to show!",
+  "text.autoconfig.microdurability.option.lowDurabilityWarning.blinkTime": "Blink speed (in seconds)",
+  "text.autoconfig.microdurability.option.lowDurabilityWarning.blinkTime.@Tooltip": "Set to 0 to disable blinking.",
+
+  "modmenu.summaryTranslation.microdurability": "A very minimal durability viewer",
+  "modmenu.descriptionTranslation.microdurability": "A very minimal durability viewer"
 }

--- a/microdurability-core/src/main/resources/assets/microdurability/lang/en_us.json
+++ b/microdurability-core/src/main/resources/assets/microdurability/lang/en_us.json
@@ -4,6 +4,9 @@
   "text.autoconfig.microdurability.category.armorBars": "Armor Bars",
   "text.autoconfig.microdurability.option.armorBars.displayArmorBars": "Display armor bars",
   "text.autoconfig.microdurability.option.armorBars.displayBarsForUndamagedArmor": "Display bars for undamaged armor",
+  "text.autoconfig.microdurability.option.armorBars.useCustomColorInBarsForUndamagedArmor": "Use custom color in bars for undamaged armor",
+  "text.autoconfig.microdurability.option.armorBars.useCustomColorInBarsForUndamagedArmor.@Tooltip": "If armor is undamaged, its bar will have custom color.",
+  "text.autoconfig.microdurability.option.armorBars.customColorInBarsForUndamagedArmor": "Custom color in bars for undamaged armor (#ARGB format)",
 
   "text.autoconfig.microdurability.category.lowDurabilityWarning": "Low Durability Warning",
   "text.autoconfig.microdurability.option.lowDurabilityWarning.displayWarningForTools": "Display warning for tools",

--- a/microdurability-core/src/main/resources/assets/microdurability/lang/ru_ru.json
+++ b/microdurability-core/src/main/resources/assets/microdurability/lang/ru_ru.json
@@ -10,6 +10,12 @@
   "text.autoconfig.microdurability.option.lowDurabilityWarning.displayWarningForArmor": "Отображать предупреждение для брони",
   "text.autoconfig.microdurability.option.lowDurabilityWarning.onlyOnMendingItems": "Отображать только на предметах с зачарованием \"Починка\"",
   "text.autoconfig.microdurability.option.lowDurabilityWarning.minDurabilityPointsBeforeWarning": "Минимальный уровень прочности до показа предупреждения",
+  "text.autoconfig.microdurability.option.lowDurabilityWarning.minDurabilityPointsBeforeWarning.@Tooltip": "Прочность предмета должна быть ниже минимального уровня и процента прочности для показа предупреждения.",
   "text.autoconfig.microdurability.option.lowDurabilityWarning.minDurabilityPercentageBeforeWarning": "Минимальный % прочности до показа предупреждения",
-  "text.autoconfig.microdurability.option.lowDurabilityWarning.blinkTime": "Задержка между миганиями (в секундах)"
+  "text.autoconfig.microdurability.option.lowDurabilityWarning.minDurabilityPercentageBeforeWarning.@Tooltip": "Прочность предмета должна быть ниже минимального уровня и процента прочности для показа предупреждения.",
+  "text.autoconfig.microdurability.option.lowDurabilityWarning.blinkTime": "Задержка между миганиями (в секундах)",
+  "text.autoconfig.microdurability.option.lowDurabilityWarning.blinkTime.@Tooltip": "Поставьте значение 0, чтобы отключить мигание.",
+
+  "modmenu.summaryTranslation.microdurability": "Очень минималистичный показатель прочности",
+  "modmenu.descriptionTranslation.microdurability": "Очень минималистичный показатель прочности"
 }

--- a/microdurability-core/src/main/resources/assets/microdurability/lang/ru_ru.json
+++ b/microdurability-core/src/main/resources/assets/microdurability/lang/ru_ru.json
@@ -4,6 +4,9 @@
   "text.autoconfig.microdurability.category.armorBars": "Индикаторы брони",
   "text.autoconfig.microdurability.option.armorBars.displayArmorBars": "Отображать индикаторы брони",
   "text.autoconfig.microdurability.option.armorBars.displayBarsForUndamagedArmor": "Отображать индикаторы для неповреждённой брони",
+  "text.autoconfig.microdurability.option.armorBars.useCustomColorInBarsForUndamagedArmor": "Использовать свой цвет на индикаторах для неповреждённой брони",
+  "text.autoconfig.microdurability.option.armorBars.useCustomColorInBarsForUndamagedArmor.@Tooltip": "Если броня не имеет повреждений, её индикатор будет иметь указанный ниже цвет.",
+  "text.autoconfig.microdurability.option.armorBars.customColorInBarsForUndamagedArmor": "Свой цвет для индикаторов для неповреждённой брони (формат #ARGB)",
 
   "text.autoconfig.microdurability.category.lowDurabilityWarning": "Предупреждение о низкой прочности",
   "text.autoconfig.microdurability.option.lowDurabilityWarning.displayWarningForTools": "Отображать предупреждение для инструментов",

--- a/microdurability-core/src/main/resources/assets/microdurability/lang/ru_ru.json
+++ b/microdurability-core/src/main/resources/assets/microdurability/lang/ru_ru.json
@@ -1,15 +1,15 @@
 {
-  "text.autoconfig.microdurability.title": "Конфигурация microDurability",
+  "text.autoconfig.microdurability.title": "Настройки microDurability",
 
-  "text.autoconfig.microdurability.category.armorBars": "Панели брони",
-  "text.autoconfig.microdurability.option.armorBars.displayArmorBars": "Отобразить панель брони",
-  "text.autoconfig.microdurability.option.armorBars.displayBarsForUndamagedArmor": "Отобразить панели для неповреждённой брони",
+  "text.autoconfig.microdurability.category.armorBars": "Индикаторы брони",
+  "text.autoconfig.microdurability.option.armorBars.displayArmorBars": "Отображать индикаторы брони",
+  "text.autoconfig.microdurability.option.armorBars.displayBarsForUndamagedArmor": "Отображать индикаторы для неповреждённой брони",
 
   "text.autoconfig.microdurability.category.lowDurabilityWarning": "Предупреждение о низкой прочности",
-  "text.autoconfig.microdurability.option.lowDurabilityWarning.displayWarningForTools": "Отобразить предупреждение для инструментов",
-  "text.autoconfig.microdurability.option.lowDurabilityWarning.displayWarningForArmor": "Отобразить предупреждение для брони",
-  "text.autoconfig.microdurability.option.lowDurabilityWarning.onlyOnMendingItems": "Отобразить только на починочных предметах",
-  "text.autoconfig.microdurability.option.lowDurabilityWarning.minDurabilityPointsBeforeWarning": "Минимум очков прочности до показа предупреждения",
-  "text.autoconfig.microdurability.option.lowDurabilityWarning.minDurabilityPercentageBeforeWarning": "Минимум % прочности до показа предупреждения",
-  "text.autoconfig.microdurability.option.lowDurabilityWarning.blinkTime": "Скорость мигания (в секундах)"
+  "text.autoconfig.microdurability.option.lowDurabilityWarning.displayWarningForTools": "Отображать предупреждение для инструментов",
+  "text.autoconfig.microdurability.option.lowDurabilityWarning.displayWarningForArmor": "Отображать предупреждение для брони",
+  "text.autoconfig.microdurability.option.lowDurabilityWarning.onlyOnMendingItems": "Отображать только на предметах с зачарованием \"Починка\"",
+  "text.autoconfig.microdurability.option.lowDurabilityWarning.minDurabilityPointsBeforeWarning": "Минимальный уровень прочности до показа предупреждения",
+  "text.autoconfig.microdurability.option.lowDurabilityWarning.minDurabilityPercentageBeforeWarning": "Минимальный % прочности до показа предупреждения",
+  "text.autoconfig.microdurability.option.lowDurabilityWarning.blinkTime": "Задержка между миганиями (в секундах)"
 }

--- a/microdurability-core/src/main/resources/fabric.mod.json
+++ b/microdurability-core/src/main/resources/fabric.mod.json
@@ -6,7 +6,8 @@
     "description": "Cross Minecraft version compatible components of microDurability",
     "authors": [
         "NebelNidas",
-        "dzwdz"
+        "dzwdz",
+        "SyberiaK"
     ],
     "contributors": [
         "BlockBuilder57"


### PR DESCRIPTION
Completes #5 and #10.
1. Added a feature to show full durability with custom color - works as it should, but needs for some more testings
![picture](https://user-images.githubusercontent.com/97897772/173889480-679949e6-7bad-4dba-8051-d587754ba371.png)
![picture](https://user-images.githubusercontent.com/97897772/173889576-bebf79c8-1db4-4887-ab96-387ccaddffe0.png)

2. `@Comment` is impossible to localize thru lang files (well, maybe we _can_ do that, but i dunno how), `        @ConfigEntry.Gui.Tooltip` is easier to interact with.
69.  `modmenu.summaryTranslation.microdurability` is a short description, `modmenu.descriptionTranslation.microdurability` is a detailed description.

Hope the first change don't break anything (i mean i'm real noob in coding Fabric mods :D).